### PR TITLE
Update README.md with nano-option for creating docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ The orders are limited to the USDT/USDC/arbUSDC stablecoin pools since they do n
 
 ## Usage
 
-Start by downloading the `docker-compose.yml` file, or copying it:
+Start by downloading the `docker-compose.yml` file, or creating it yourself:
+
+```bash
+nano docker-compose.yml
+```
+
+Paste and adjust the below into the empty file.
 
 ```yml
 services:


### PR DESCRIPTION
Adding 'nano'-option to create locally the docker-compose-file.